### PR TITLE
Add support for command/subcommand documentation

### DIFF
--- a/example/main.rs
+++ b/example/main.rs
@@ -25,8 +25,13 @@ fn command_four() -> String {
     "command four".to_string()
 }
 
-subcommands!(my_subcommands, [command_two, command_three, command_four]);
-subcommands!(cli, [command_one, my_subcommands]);
+subcommands!(
+    /// These are the subcommands
+    my_subcommands, [command_two, command_three, command_four]);
+
+subcommands!(
+    /// Example docs for the "root"
+    cli, [command_one, my_subcommands]);
 
 fn main() {
     cli::run(cli::Args::parse());

--- a/readme.md
+++ b/readme.md
@@ -12,8 +12,7 @@ This is a work in progress. The core functionality is implemented, but if you wa
 Known issues:
 - [ ] every command must have a return type that implements `Display`
 - [ ] positional arguments are not yet supported
-- [ ] comments on arguments/subcommands are not yet supported
-
+- [ ] argument docs are not yet supported
 
 ## Installation
 
@@ -59,8 +58,19 @@ fn command_three(a: i32, b: i32) -> String {
     format!("the difference is {}", a - b)
 }
 
-subcommands!(my_subcommands, [command_two, command_three]);
-subcommands!(cli, [command_one, my_subcommands]);
+/// Example: cargo run -- my-subcommands command-four
+#[command]
+fn command_four() -> String {
+    "command four".to_string()
+}
+
+subcommands!(
+    /// These are the subcommands
+    my_subcommands, [command_two, command_three, command_four]);
+
+subcommands!(
+    /// Example docs for the "root"
+    cli, [command_one, my_subcommands]);
 
 fn main() {
     cli::run(cli::Args::parse());
@@ -68,4 +78,5 @@ fn main() {
 
 // you can also use `--help` as you would expect
 // Example: cargo run -- my-subcommands --help
+
 ```

--- a/tests/test_cli_subcommand.rs
+++ b/tests/test_cli_subcommand.rs
@@ -40,6 +40,7 @@ pub fn test_command_macro() {
 #[test]
 pub fn test_command_macro_no_args() {
     let in_stream = quote! {
+        /// doc comment test
         fn my_func() -> i32 {
             42
         }
@@ -53,6 +54,7 @@ pub fn test_command_macro_no_args() {
         
             #[derive(Parser)]
             #[command(version, about, long_about = None)]
+            #[doc = r" doc comment test"]
             pub struct Args {}
         
             pub fn run(Args {}: Args) {
@@ -61,6 +63,7 @@ pub fn test_command_macro_no_args() {
             }
         }
 
+        #[doc = r" doc comment test"]
         fn my_func() -> i32 {
             42
         }        


### PR DESCRIPTION
Forwards the doc comments on `#[command]` items and `subcommands!` cli idents:

```rust
/// Example: cargo run -- command-one --a 3
#[command]
fn command_one(a: i32, b: Option<i32>) -> i32 {
    a + b.unwrap_or(0)
}
```

```rust
subcommands!(
    /// These are the subcommands
    my_subcommands, [command_two, command_three, command_four]);

subcommands!(
    /// Example docs for the "root"
    cli, [command_one, my_subcommands]);
```

yields

```text
Example docs for the "root"

Usage: cli <COMMAND>

Commands:
  command-one     Example: cargo run -- command-one --a 3
  my-subcommands  These are the subcommands
  help            Print this message or the help of the given subcommand(s)

Options:
  -h, --help     Print help
  -V, --version  Print version
```